### PR TITLE
refactor: add ConfigManager interface

### DIFF
--- a/cmd/account/ls.go
+++ b/cmd/account/ls.go
@@ -3,9 +3,9 @@ package account
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
+	"github.com/pixel365/bx/internal"
 
-	"github.com/pixel365/bx/internal/config"
+	"github.com/spf13/cobra"
 )
 
 func lsCmd() *cobra.Command {
@@ -13,18 +13,18 @@ func lsCmd() *cobra.Command {
 		Use:   "ls",
 		Short: "List accounts",
 		RunE: func(c *cobra.Command, _ []string) error {
-			conf, err := config.GetConfig()
-			if err != nil {
-				return err
+			conf, ok := c.Context().Value(internal.CfgContextKey).(internal.ConfigManager)
+			if !ok {
+				return internal.NoConfigError
 			}
 
-			if len(conf.Accounts) == 0 {
+			if len(conf.GetAccounts()) == 0 {
 				fmt.Println("No accounts found")
 				return nil
 			}
 
 			verbose, _ := c.Flags().GetBool("verbose")
-			for _, acc := range conf.Accounts {
+			for _, acc := range conf.GetAccounts() {
 				acc.PrintSummary(verbose)
 			}
 

--- a/cmd/account/modules.go
+++ b/cmd/account/modules.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/pixel365/bx/internal"
 
-	"github.com/pixel365/bx/internal/config"
-
 	"github.com/spf13/cobra"
 )
 
@@ -17,15 +15,15 @@ func moduleCmd() *cobra.Command {
 		Short:   "List available modules",
 		Aliases: []string{"mods"},
 		RunE: func(c *cobra.Command, _ []string) error {
-			conf, err := config.GetConfig()
-			if err != nil {
-				return err
+			conf, ok := c.Context().Value(internal.CfgContextKey).(internal.ConfigManager)
+			if !ok {
+				return internal.NoConfigError
 			}
 
 			login, _ := c.Flags().GetString("login")
 			login = strings.TrimSpace(login)
 			if login == "" {
-				if err = internal.Choose(&conf.Accounts, &login,
+				if err := internal.Choose(conf.GetAccounts(), &login,
 					"Select the account whose modules you want to show:"); err != nil {
 					return err
 				}
@@ -33,7 +31,7 @@ func moduleCmd() *cobra.Command {
 
 			j := 0
 			verbose, _ := c.Flags().GetBool("verbose")
-			for _, module := range conf.Modules {
+			for _, module := range conf.GetModules() {
 				if module.Login == login {
 					j++
 					module.PrintSummary(verbose)

--- a/cmd/config/info.go
+++ b/cmd/config/info.go
@@ -1,9 +1,11 @@
 package config
 
 import (
-	cfg "github.com/pixel365/bx/internal/config"
+	"errors"
 
 	"github.com/spf13/cobra"
+
+	"github.com/pixel365/bx/internal"
 )
 
 func infoCmd() *cobra.Command {
@@ -12,9 +14,9 @@ func infoCmd() *cobra.Command {
 		Aliases: []string{"i"},
 		Short:   "Get configuration information",
 		RunE: func(c *cobra.Command, _ []string) error {
-			conf, err := cfg.GetConfig()
-			if err != nil {
-				return err
+			conf, ok := c.Context().Value(internal.CfgContextKey).(internal.Printer)
+			if !ok {
+				return errors.New("no config found in context")
 			}
 
 			verbose, _ := c.Flags().GetBool("verbose")

--- a/cmd/config/reset.go
+++ b/cmd/config/reset.go
@@ -1,31 +1,32 @@
 package config
 
 import (
+	"errors"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/pixel365/bx/internal"
-	cfg "github.com/pixel365/bx/internal/config"
 )
 
 func resetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Reset configuration",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			conf, err := cfg.GetConfig()
-			if err != nil {
-				return err
+		RunE: func(c *cobra.Command, _ []string) error {
+			conf, ok := c.Context().Value(internal.CfgContextKey).(internal.ConfigManager)
+			if !ok {
+				return errors.New("no config found in context")
 			}
 
 			confirm := false
-			if err = internal.Confirmation(&confirm,
+			if err := internal.Confirmation(&confirm,
 				"Are you sure you want to reset all settings and clear the configuration file?"); err != nil {
 				return err
 			}
 
 			if confirm {
-				if err = conf.Reset(); err != nil {
+				if err := conf.Reset(); err != nil {
 					return err
 				}
 

--- a/cmd/module/ls.go
+++ b/cmd/module/ls.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/pixel365/bx/internal"
 
-	"github.com/pixel365/bx/internal/config"
-
 	"github.com/spf13/cobra"
 )
 
@@ -16,12 +14,12 @@ func lsCmd() *cobra.Command {
 		Use:   "ls",
 		Short: "List available modules",
 		RunE: func(c *cobra.Command, _ []string) error {
-			conf, err := config.GetConfig()
-			if err != nil {
-				return err
+			conf, ok := c.Context().Value(internal.CfgContextKey).(internal.ConfigManager)
+			if !ok {
+				return internal.NoConfigError
 			}
 
-			if len(conf.Modules) == 0 {
+			if len(conf.GetModules()) == 0 {
 				fmt.Println("No modules found")
 				return nil
 			}
@@ -35,7 +33,7 @@ func lsCmd() *cobra.Command {
 				login = ""
 			} else {
 				if login == "" {
-					if err = internal.Choose(&conf.Accounts, &login,
+					if err := internal.Choose(conf.GetAccounts(), &login,
 						"Select the account whose modules you want to see:"); err != nil {
 						return err
 					}
@@ -43,12 +41,12 @@ func lsCmd() *cobra.Command {
 			}
 
 			if login != "" {
-				for _, mod := range conf.Modules {
+				for _, mod := range conf.GetModules() {
 					mod.PrintSummary(verbose)
 				}
 			} else {
 				j := 0
-				for _, mod := range conf.Modules {
+				for _, mod := range conf.GetModules() {
 					if mod.Login != login {
 						continue
 					}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 
+	"github.com/pixel365/bx/internal"
+
 	"github.com/pixel365/bx/cmd/config"
 
 	"github.com/pixel365/bx/cmd/module"
@@ -12,15 +14,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Execute(ctx context.Context) error {
-	cmd := rootCmd(ctx)
+func Execute(ctx context.Context, conf internal.ConfigManager) error {
+	cmd := rootCmd(ctx, conf)
 	return cmd.ExecuteContext(ctx)
 }
 
-func rootCmd(ctx context.Context) *cobra.Command {
+func rootCmd(ctx context.Context, conf internal.ConfigManager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bx",
 		Short: "Command-line tool for developers of 1C-Bitrix platform modules.",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			ctx = context.WithValue(ctx, internal.CfgContextKey, conf)
+			cmd.SetContext(ctx)
+		},
 	}
 
 	cmd.AddCommand(account.NewAccountCommand(ctx))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,20 +1,10 @@
 package config
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/pixel365/bx/internal/model"
-)
-
-const (
-	configDirName  = "/.bx"
-	configFileName = "/.config.json"
 )
 
 type Config struct {
@@ -23,109 +13,4 @@ type Config struct {
 	Accounts  []model.Account `json:"accounts,omitempty"`
 	Modules   []model.Module  `json:"modules,omitempty"`
 	mu        sync.RWMutex
-}
-
-func (o *Config) PrintSummary(verbose bool) {
-	if verbose {
-		fmt.Printf("Created At: %s\n", o.CreatedAt)
-		fmt.Printf("Updated At: %s\n", o.UpdatedAt)
-		fmt.Printf("Accounts: %d\n", len(o.Accounts))
-		fmt.Printf("Modules: %d\n", len(o.Modules))
-	} else {
-		fmt.Printf("Created At: %s\n", o.CreatedAt)
-		fmt.Printf("Updated At: %s\n", o.UpdatedAt)
-	}
-}
-
-func (o *Config) Save() error {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	filePath, err := path()
-	if err != nil {
-		return err
-	}
-
-	o.UpdatedAt = time.Now().UTC()
-	data, err := json.Marshal(o)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(filePath, data, 0600)
-}
-
-func (o *Config) Reset() error {
-	o.mu.Lock()
-
-	now := time.Now().UTC()
-	o.CreatedAt = now
-	o.UpdatedAt = now
-	o.Accounts = nil
-	o.Modules = nil
-
-	o.mu.Unlock()
-
-	return o.Save()
-}
-
-func GetConfig() (*Config, error) {
-	var err error
-
-	filePath, err := path()
-	if err != nil {
-		return nil, err
-	}
-
-	absPath, err := filepath.Abs(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	cleanPath := filepath.Clean(absPath)
-
-	cfg := &Config{}
-	content, err := os.ReadFile(cleanPath)
-	if err == nil {
-		err = json.Unmarshal(content, cfg)
-	} else {
-		if os.IsNotExist(err) {
-			now := time.Now().UTC()
-			cfg.CreatedAt = now
-			cfg.UpdatedAt = now
-			err = cfg.Save()
-		}
-	}
-
-	return cfg, err
-}
-
-func path() (string, error) {
-	dir, err := dirPath()
-	if err != nil {
-		return "", err
-	}
-
-	return dir + configFileName, nil
-}
-
-func dirPath() (string, error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-
-	dirFullPath := dir + configDirName
-	if _, err = os.Stat(dirFullPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			err = os.Mkdir(dirFullPath, 0750)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			return "", err
-		}
-	}
-
-	return dirFullPath, nil
 }

--- a/internal/config/config_impl.go
+++ b/internal/config/config_impl.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pixel365/bx/internal/model"
+)
+
+const (
+	configDirName  = "/.bx"
+	configFileName = "/.config.json"
+)
+
+func (o *Config) PrintSummary(verbose bool) {
+	if verbose {
+		fmt.Printf("Created At: %s\n", o.CreatedAt)
+		fmt.Printf("Updated At: %s\n", o.UpdatedAt)
+		fmt.Printf("Accounts: %d\n", len(o.Accounts))
+		fmt.Printf("Modules: %d\n", len(o.Modules))
+	} else {
+		fmt.Printf("Created At: %s\n", o.CreatedAt)
+		fmt.Printf("Updated At: %s\n", o.UpdatedAt)
+	}
+}
+
+func (o *Config) Save() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	filePath, err := path()
+	if err != nil {
+		return err
+	}
+
+	o.UpdatedAt = time.Now().UTC()
+	data, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0600)
+}
+
+func (o *Config) Reset() error {
+	o.mu.Lock()
+
+	now := time.Now().UTC()
+	o.CreatedAt = now
+	o.UpdatedAt = now
+	o.Accounts = nil
+	o.Modules = nil
+
+	o.mu.Unlock()
+
+	return o.Save()
+}
+
+func (o *Config) GetAccounts() []model.Account {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.Accounts
+}
+
+func (o *Config) GetModules() []model.Module {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.Modules
+}
+
+func (o *Config) SetAccounts(accounts ...model.Account) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.Accounts = accounts
+}
+
+func (o *Config) SetModules(modules ...model.Module) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.Modules = modules
+}
+
+func (o *Config) AddAccounts(accounts ...model.Account) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.Accounts = append(o.Accounts, accounts...)
+}
+
+func (o *Config) AddModules(modules ...model.Module) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.Modules = append(o.Modules, modules...)
+}
+
+func Load() (*Config, error) {
+	var err error
+
+	filePath, err := path()
+	if err != nil {
+		return nil, err
+	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanPath := filepath.Clean(absPath)
+
+	cfg := &Config{}
+	content, err := os.ReadFile(cleanPath)
+	if err == nil {
+		err = json.Unmarshal(content, cfg)
+	} else {
+		if os.IsNotExist(err) {
+			now := time.Now().UTC()
+			cfg.CreatedAt = now
+			cfg.UpdatedAt = now
+			err = cfg.Save()
+		}
+	}
+
+	return cfg, err
+}
+
+func path() (string, error) {
+	dir, err := dirPath()
+	if err != nil {
+		return "", err
+	}
+
+	return dir + configFileName, nil
+}
+
+func dirPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	dirFullPath := dir + configDirName
+	if _, err = os.Stat(dirFullPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = os.Mkdir(dirFullPath, 0750)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	return dirFullPath, nil
+}

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -8,6 +8,14 @@ import (
 	"github.com/pixel365/bx/internal/model"
 )
 
+type Cfg string
+
+var NoConfigError = errors.New("no config found in context")
+
+const (
+	CfgContextKey Cfg = "config"
+)
+
 type Printer interface {
 	PrintSummary(verbose bool)
 }
@@ -16,12 +24,23 @@ type OptionProvider interface {
 	Option() string
 }
 
-func AccountIndexByLogin(accounts *[]model.Account, login string) (int, error) {
-	if len(*accounts) == 0 {
+type ConfigManager interface {
+	Save() error
+	Reset() error
+	GetAccounts() []model.Account
+	GetModules() []model.Module
+	SetAccounts(...model.Account)
+	SetModules(...model.Module)
+	AddAccounts(...model.Account)
+	AddModules(...model.Module)
+}
+
+func AccountIndexByLogin(accounts []model.Account, login string) (int, error) {
+	if len(accounts) == 0 {
 		return 0, errors.New("no accounts found")
 	}
 
-	for i, account := range *accounts {
+	for i, account := range accounts {
 		if account.Login == login {
 			return i, nil
 		}
@@ -43,13 +62,13 @@ func Confirmation(flag *bool, title string) error {
 	return nil
 }
 
-func Choose[T OptionProvider](items *[]T, value *string, title string) error {
-	if len(*items) == 0 {
+func Choose[T OptionProvider](items []T, value *string, title string) error {
+	if len(items) == 0 {
 		return errors.New("no items found")
 	}
 
 	var options []huh.Option[string]
-	for _, item := range *items {
+	for _, item := range items {
 		options = append(options, huh.NewOption(item.Option(), item.Option()))
 	}
 

--- a/internal/validators.go
+++ b/internal/validators.go
@@ -3,18 +3,16 @@ package internal
 import (
 	"errors"
 	"strings"
-
-	"github.com/pixel365/bx/internal/config"
 )
 
-func ValidateAccountLogin(login string, conf *config.Config) error {
+func ValidateAccountLogin(login string, conf ConfigManager) error {
 	value := strings.TrimSpace(login)
 	if value == "" {
 		return errors.New("login is empty")
 	}
 
-	if len(conf.Accounts) > 0 {
-		for _, account := range conf.Accounts {
+	if len(conf.GetAccounts()) > 0 {
+		for _, account := range conf.GetAccounts() {
 			if account.Login == value {
 				return errors.New("an account with this login already exists")
 			}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/pixel365/bx/internal"
+
+	cfg "github.com/pixel365/bx/internal/config"
+
 	"github.com/pixel365/bx/cmd"
 )
 
@@ -14,7 +18,13 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := cmd.Execute(ctx); err != nil {
+	conf, err := cfg.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
+	var configManager internal.ConfigManager = conf
+
+	if err := cmd.Execute(ctx, configManager); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Description of Changes:

- Added ConfigManager interface:

  The ConfigManager interface defines the basic methods for interacting with the configuration, including methods for saving, resetting, and retrieving data (such as accounts and modules).
This improves the abstraction of configuration handling and its interaction with various parts of the application.

- Loading config in rootCmd:

  The configuration is loaded in the root-level rootCmd command and passed through the context.
This ensures that the configuration is accessible at all command levels, simplifying state management and avoiding direct reliance on global variables.

- Using context to pass config:

  The configuration is stored in the context using the CfgContextKey key.
This allows any sub-command handler to extract the config from the context and use it without explicitly passing it in every call.