### PR TITLE
feat(build): include only added and modified files in distribution

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -498,7 +498,7 @@ func HandleStages(
 
 		wg.Add(1)
 
-		go handleStage(m.Ctx, wg, errCh, log, &m.Ignore, stage, dir, m.StageCallback)
+		go handleStage(m.Ctx, wg, errCh, log, m, stage, dir, m.StageCallback)
 	}
 
 	return nil

--- a/internal/module.go
+++ b/internal/module.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"sync"
 )
 
 type FileExistsAction string
@@ -57,18 +58,20 @@ type Module struct {
 	Ctx            context.Context     `yaml:"-"`
 	Variables      map[string]string   `yaml:"variables,omitempty"`
 	Run            map[string][]string `yaml:"run,omitempty"`
-	Name           string              `yaml:"name"`
-	Version        string              `yaml:"version"`
+	changes        *Changes            `yaml:"-"`
+	Repository     string              `yaml:"repository,omitempty"`
 	Account        string              `yaml:"account"`
 	BuildDirectory string              `yaml:"buildDirectory,omitempty"`
 	LogDirectory   string              `yaml:"logDirectory,omitempty"`
-	Repository     string              `yaml:"repository,omitempty"`
+	Version        string              `yaml:"version"`
+	Name           string              `yaml:"name"`
 	Changelog      Changelog           `yaml:"changelog,omitempty"`
 	Builds         Builds              `yaml:"builds"`
 	Stages         []Stage             `yaml:"stages"`
 	Ignore         []string            `yaml:"ignore"`
 	Callbacks      []Callback          `yaml:"callbacks,omitempty"`
 	LastVersion    bool                `yaml:"-"`
+	mu             sync.Mutex          `yaml:"-"`
 }
 
 func (m *Module) GetVersion() string {

--- a/internal/module_impl.go
+++ b/internal/module_impl.go
@@ -279,3 +279,23 @@ func (m *Module) FindStage(name string) (Stage, error) {
 
 	return Stage{}, fmt.Errorf("stage `%s` not found", name)
 }
+
+func (m *Module) GetChanges() *Changes {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.Repository == "" {
+		return nil
+	}
+
+	if m.changes == nil {
+		changes, err := ChangesList(m.Repository, m.Changelog)
+		if err != nil {
+			return nil
+		}
+
+		m.changes = changes
+	}
+
+	return m.changes
+}

--- a/internal/repo.go
+++ b/internal/repo.go
@@ -15,6 +15,79 @@ import (
 
 type CommitFilterFunc func(string, TypeValue[ChangelogConditionType, []string]) bool
 
+type Changes struct {
+	Added    []string
+	Modified []string
+	Deleted  []string
+}
+
+// IsChangedFile checks whether the given file path corresponds to a file that has been added or modified.
+//
+// Parameters:
+//   - path: The file path to check.
+//
+// Returns:
+//   - true if the file is in the list of added or modified files.
+//   - false otherwise.
+//
+// Behavior:
+//   - Iterates through the `Added` and `Modified` slices of the `Changes` struct.
+//   - Uses `strings.HasSuffix` to check if the provided path ends with any of the added or modified file names.
+//   - Returns true on the first match, otherwise false.
+//
+// Notes:
+//   - This method assumes that `o.Added` and `o.Modified` contain relative or base file names.
+//   - If files are stored with full paths in `o.Added` and `o.Modified`, this method may produce false negatives.
+//
+// Example:
+//
+//	changes := Changes{
+//	    Added:    []string{"file1.txt", "dir/file2.go"},
+//	    Modified: []string{"config.yaml"},
+//	}
+//	fmt.Println(changes.IsChangedFile("project/dir/file2.go")) // true
+//	fmt.Println(changes.IsChangedFile("config.yaml"))         // true
+//	fmt.Println(changes.IsChangedFile("untracked.txt"))       // false
+func (o *Changes) IsChangedFile(path string) bool {
+	for _, f := range o.Added {
+		if strings.HasSuffix(path, f) {
+			return true
+		}
+	}
+
+	for _, f := range o.Modified {
+		if strings.HasSuffix(path, f) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// OpenRepository opens an existing Git repository at the specified path.
+//
+// Parameters:
+//   - repository: The file system path to the Git repository.
+//
+// Returns:
+//   - A pointer to a `git.Repository` instance if the repository is successfully opened.
+//   - An error if the repository cannot be opened.
+//
+// Behavior:
+//   - Uses `git.PlainOpen` to open the repository.
+//   - Wraps the error with additional context if opening fails.
+//
+// Example:
+//
+//	repo, err := OpenRepository("/path/to/repo")
+//	if err != nil {
+//	    log.Fatalf("Failed to open repository: %v", err)
+//	}
+//	fmt.Println("Repository opened:", repo)
+//
+// Notes:
+//   - The function does not initialize a new repository; it only opens an existing one.
+//   - Ensure that the provided path is a valid Git repository.
 func OpenRepository(repository string) (*git.Repository, error) {
 	r, err := git.PlainOpen(repository)
 	if err != nil {
@@ -24,6 +97,40 @@ func OpenRepository(repository string) (*git.Repository, error) {
 	return r, nil
 }
 
+// ChangelogList generates a list of commits between two specified points in a Git repository,
+// applying given changelog rules.
+//
+// Parameters:
+//   - repository: The file system path to the Git repository.
+//   - rules: A `Changelog` struct defining the range of commits and sorting rules.
+//
+// Returns:
+//   - A slice of commit hashes as strings.
+//   - An error if the repository cannot be opened or commit retrieval fails.
+//
+// Behavior:
+//   - If `rules.From` or `rules.To` are not properly set, it returns an empty list with no error.
+//   - Opens the specified Git repository using `OpenRepository`.
+//   - Retrieves commits within the specified range using `listOfCommits`.
+//   - Sorts commits if `rules.Sort` is set to `Asc` (ascending) or `Desc` (descending).
+//
+// Example:
+//
+//	rules := Changelog{
+//	    From: Tag{"v1.0.0"},
+//	    To:   Tag{"v2.0.0"},
+//	    Sort: Desc,
+//	}
+//	commits, err := ChangelogList("/path/to/repo", rules)
+//	if err != nil {
+//	    log.Fatalf("Failed to generate changelog: %v", err)
+//	}
+//	fmt.Println("Commits:", commits)
+//
+// Notes:
+//   - Sorting is applied only if `rules.Sort` is explicitly set.
+//   - Uses `listOfCommits` with a predefined `CommitFilter` function.
+//   - The function does not modify the repository; it only queries commit history.
 func ChangelogList(repository string, rules Changelog) ([]string, error) {
 	if rules.From.Type == "" || rules.To.Type == "" {
 		return []string{}, nil
@@ -59,6 +166,37 @@ func ChangelogList(repository string, rules Changelog) ([]string, error) {
 	return commits, nil
 }
 
+// CommitFilter checks whether a commit message matches a set of conditions.
+//
+// Parameters:
+//   - message: The commit message to evaluate.
+//   - conditions: A `TypeValue` struct containing a list of regex conditions and a filter type
+//     (`Include` or `Exclude`).
+//
+// Returns:
+//   - true if the commit message satisfies the filtering conditions.
+//   - false if the message does not match an `Include` condition or matches an `Exclude` condition.
+//
+// Behavior:
+//   - If `conditions.Value` is empty, it returns `true` (no filtering applied).
+//   - Iterates through all regex conditions in `conditions.Value`.
+//   - If `conditions.Type` is `Include`, returns `true` on the first match.
+//   - If `conditions.Type` is `Exclude`, returns `false` on the first match.
+//   - If no matches are found, returns `false` for `Include` and `true` for `Exclude`.
+//
+// Example:
+//
+//	conditions := TypeValue[ChangelogConditionType, []string]{
+//	    Type:  Include,
+//	    Value: []string{".*fix.*", ".*feature.*"},
+//	}
+//	fmt.Println(CommitFilter("fix: bug fixed", conditions)) // true
+//	fmt.Println(CommitFilter("chore: update docs", conditions)) // false
+//
+// Notes:
+//   - Regular expressions are compiled dynamically; invalid regex patterns are ignored.
+//   - If regex compilation fails, the loop breaks, and filtering may be incomplete.
+//   - Ensures `matched` is set correctly for both `Include` and `Exclude` conditions.
 func CommitFilter(message string, conditions TypeValue[ChangelogConditionType, []string]) bool {
 	if len(conditions.Value) == 0 {
 		return true
@@ -87,6 +225,37 @@ func CommitFilter(message string, conditions TypeValue[ChangelogConditionType, [
 	return matched
 }
 
+// listOfCommits retrieves a list of commit messages from a Git repository
+// within a specified range, applying a filtering function.
+//
+// Parameters:
+//   - repository: A pointer to a `git.Repository` instance.
+//   - rules: A `Changelog` struct defining the commit range and filtering rules.
+//   - filter: A function that determines whether a commit message should be included.
+//
+// Returns:
+//   - A slice of commit messages that match the filtering criteria.
+//   - An error if the repository is nil, commit history retrieval fails, or iteration encounters an issue.
+//
+// Behavior:
+//   - Calls `hashes` to determine the start and end commit hashes based on `rules`.
+//   - Retrieves the commit log starting from `endHash`.
+//   - Iterates through commits, applying `filter` to the first line of each commit message.
+//   - Stops iteration when the `startHash` commit is reached.
+//   - If a commit matches the filter condition, its message is added to the result slice.
+//
+// Example:
+//
+//	commits, err := listOfCommits(repo, rules, CommitFilter)
+//	if err != nil {
+//	    log.Fatalf("Failed to list commits: %v", err)
+//	}
+//	fmt.Println("Filtered commits:", commits)
+//
+// Notes:
+//   - Uses `plumbing.ErrObjectNotFound` to stop processing when `startHash` is reached.
+//   - Ensures the commit iterator is closed using `defer iter.Close()`.
+//   - If an error occurs while iterating, it is wrapped and returned unless it's `ErrObjectNotFound`.
 func listOfCommits(
 	repository *git.Repository,
 	rules Changelog,
@@ -127,6 +296,35 @@ func listOfCommits(
 	return result, nil
 }
 
+// hashes resolves the start and end commit hashes based on the given changelog rules.
+//
+// Parameters:
+//   - repository: A pointer to a `git.Repository` instance.
+//   - rules: A `Changelog` struct specifying the commit range.
+//
+// Returns:
+//   - `startHash`: The resolved plumbing.Hash for the starting commit.
+//   - `endHash`: The resolved plumbing.Hash for the ending commit.
+//   - An error if the repository is nil or if a commit hash cannot be resolved.
+//
+// Behavior:
+//   - If the repository is nil, returns `plumbing.ZeroHash` for both values and an error.
+//   - If `rules.From.Type` is `Commit`, directly converts `rules.From.Value` into a hash.
+//   - Otherwise, attempts to resolve `rules.From.Value` as a branch, tag, or other reference.
+//   - Performs the same logic for `rules.To`.
+//   - If resolving a commit hash fails, an error is returned.
+//
+// Example:
+//
+//	start, end, err := hashes(repo, rules)
+//	if err != nil {
+//	    log.Fatalf("Failed to resolve commit hashes: %v", err)
+//	}
+//	fmt.Println("Start Hash:", start, "End Hash:", end)
+//
+// Notes:
+//   - The function supports resolving both direct commit hashes and references (branches/tags).
+//   - Uses `repository.ResolveRevision` to translate references into commit hashes.
 func hashes(repository *git.Repository, rules Changelog) (plumbing.Hash, plumbing.Hash, error) {
 	if repository == nil {
 		return plumbing.ZeroHash, plumbing.ZeroHash, errors.New("repository is nil")
@@ -156,4 +354,83 @@ func hashes(repository *git.Repository, rules Changelog) (plumbing.Hash, plumbin
 	}
 
 	return startHash, endHash, nil
+}
+
+// ChangesList generates a list of file changes between two commits in a Git repository.
+//
+// Parameters:
+//   - repository: The file system path to the Git repository.
+//   - rules: A `Changelog` struct defining the commit range for comparison.
+//
+// Returns:
+//   - A pointer to a `Changes` struct containing lists of added, modified, and deleted files.
+//   - An error if the repository cannot be opened, commit hashes cannot be resolved, or patch generation fails.
+//
+// Behavior:
+//   - Opens the Git repository using `OpenRepository`.
+//   - Resolves the start and end commit hashes using `hashes`.
+//   - Retrieves the commit objects corresponding to these hashes.
+//   - Generates a diff (`Patch`) between the two commits.
+//   - Iterates through the `FilePatches()` to categorize files as added, modified, or deleted.
+//
+// Example:
+//
+//	changes, err := ChangesList("/path/to/repo", rules)
+//	if err != nil {
+//	    log.Fatalf("Failed to generate changes list: %v", err)
+//	}
+//	fmt.Println("Added files:", changes.Added)
+//	fmt.Println("Modified files:", changes.Modified)
+//	fmt.Println("Deleted files:", changes.Deleted)
+//
+// Notes:
+//   - If `from == nil`, the file was newly added.
+//   - If `to == nil`, the file was deleted.
+//   - Otherwise, the file was modified.
+//   - The function does not modify the repository; it only analyzes commit differences.
+func ChangesList(repository string, rules Changelog) (*Changes, error) {
+	r, err := OpenRepository(repository)
+	if err != nil {
+		return nil, err
+	}
+
+	if r == nil {
+		return nil, errors.New("repository is nil")
+	}
+
+	startHash, endHash, err := hashes(r, rules)
+	if err != nil {
+		return nil, fmt.Errorf("repository [%s]: %w", repository, err)
+	}
+
+	startCommit, err := r.CommitObject(startHash)
+	if err != nil {
+		return nil, fmt.Errorf("repository [%s]: %w", repository, err)
+	}
+
+	endCommit, err := r.CommitObject(endHash)
+	if err != nil {
+		return nil, fmt.Errorf("repository [%s]: %w", repository, err)
+	}
+
+	patch, err := startCommit.Patch(endCommit)
+	if err != nil {
+		return nil, fmt.Errorf("repository [%s]: %w", repository, err)
+	}
+
+	c := Changes{}
+
+	for _, filePatch := range patch.FilePatches() {
+		from, to := filePatch.Files()
+
+		if from == nil {
+			c.Added = append(c.Added, to.Path())
+		} else if to == nil {
+			c.Deleted = append(c.Deleted, from.Path())
+		} else {
+			c.Modified = append(c.Modified, from.Path())
+		}
+	}
+
+	return &c, nil
 }

--- a/internal/repo_test.go
+++ b/internal/repo_test.go
@@ -174,3 +174,30 @@ func Test_hashes(t *testing.T) {
 		})
 	}
 }
+
+func TestChangesList(t *testing.T) {
+	type args struct {
+		repository string
+		rules      Changelog
+	}
+	tests := []struct {
+		want    *Changes
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{nil, "empty repository", args{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ChangesList(tt.args.repository, tt.args.rules)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ChangesList() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ChangesList() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR optimizes the distribution build process by including only files that have been **added** or **modified** in the repository.

## Changes  
- Implemented filtering logic to exclude unchanged files from the distribution.  
- Integrated repository change tracking to determine which files should be included.  
- Improved build performance by reducing unnecessary file processing. 